### PR TITLE
Fix the 0ad dependency to its latest format.

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -4,7 +4,7 @@
 	"label": "No gore mod",
 	"url": "https://github.com/0ADMods/no-blood-and-gore-mod",
 	"description": "A mod that disables the blood and gore of the game.",
-	"dependencies": ["0ad=0.0.27"],
+	"dependencies": ["0ad=0.27.0"],
 	"ignoreInCompatibilityChecks": true,
 	"type": "Gameplay"
 }


### PR DESCRIPTION
This issue follows https://github.com/0ADMods/no-blood-and-gore-mod/issues/3 , bringing the mod to be compatible and publishable to the official 0ad directory.

The reason why this change is needed is that 0ad changed its naming policy, and seemingly updated its version, too. It's now specified as "0.27.0" as opposed to the old "0.0.27". See the screenshot:

![2025-05-23_20 32 15e](https://github.com/user-attachments/assets/4083d75c-c902-47c7-8c19-b9d520765492)
